### PR TITLE
Fix login view autocapitalization

### DIFF
--- a/vibecast/LoginView.swift
+++ b/vibecast/LoginView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+
+    var body: some View {
+        VStack {
+            TextField("Email", text: $email)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+            SecureField("Password", text: $password)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+            Button("Log In") {
+                // handle login
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    LoginView()
+}


### PR DESCRIPTION
## Summary
- Add new login view
- Use `textInputAutocapitalization` and disable autocorrection for email/password fields

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68afadc4f8c48332851ad9e5d0fa71c3